### PR TITLE
[Docs] 달력 수정

### DIFF
--- a/WebContent/member_registration/script/jquery-ui.js
+++ b/WebContent/member_registration/script/jquery-ui.js
@@ -7376,12 +7376,12 @@ function Datepicker() {
 		currentText: "Today", // Display text for current month link
 		monthNames: [ "January", "February", "March", "April", "May", "June",
 			"July", "August", "September", "October", "November", "December" ], // Names of months for drop-down and formatting
-		monthNamesShort: [ "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec" ], // For formatting
+		monthNamesShort: [ "1월", "2월", "3월", "4월", "5월", "6월", "7월", "8월", "9월", "10월", "11월", "12월" ], // For formatting
 		dayNames: [ "Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday" ], // For formatting
 		dayNamesShort: [ "Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat" ], // For formatting
 		dayNamesMin: [ "Su", "Mo", "Tu", "We", "Th", "Fr", "Sa" ], // Column headings for days starting at Sunday
 		weekHeader: "Wk", // Column header for week of the year
-		dateFormat: "mm/dd/yy", // See format options on parseDate
+		dateFormat: "yy-mm-dd", // See format options on parseDate
 		firstDay: 0, // The first day of the week, Sun = 0, Mon = 1, ...
 		isRTL: false, // True if right-to-left language, false if left-to-right
 		showMonthAfterYear: false, // True if the year select precedes month, false for month then year


### PR DESCRIPTION
1. 회원등록에 생일에 나오는 달력을 수정하였습니다. 
1-1. 달력의 월이 영어였는데 한글로 수정하였습니다.
1-2. 달력에 월 일 년 이였지만 년월일로 바꾸었습니다.

#Resolves: #1